### PR TITLE
Highlight syntax when the file name is tmux.conf

### DIFF
--- a/Tmux.tmLanguage
+++ b/Tmux.tmLanguage
@@ -5,6 +5,7 @@
 	<key>fileTypes</key>
 	<array>
 		<string>.tmux.conf</string>
+		<string>tmux.conf</string>
 	</array>
 	<key>name</key>
 	<string>Tmux</string>


### PR DESCRIPTION
(it doesn't have the dot)

This can be useful if you, like me, save your config files into github and just symlink then.

For example this is my [tmux.conf](https://github.com/lucasprag/dotfiles/blob/master/tmux.conf) and this syntax highlight doesn't work for it.

It's convenient for me to not have the dot in the file so it's no hidden locally when editing my config repository.

I'm using my own version of this plugin locally, but it would be nice to share it with more people.

Thanks for this plugin, it works really well =)